### PR TITLE
Rotterdam- Add Task Card Component

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/chip/DateChip.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/chip/DateChip.kt
@@ -1,0 +1,39 @@
+package com.amsterdam.cutetudee.presentation.component.chip
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.amsterdam.cutetudee.R
+import com.amsterdam.cutetudee.presentation.theme.AppTheme
+
+@Composable
+fun DateChip(
+    date: String,
+    modifier: Modifier = Modifier,
+    contentColor: Color = AppTheme.color.body
+) {
+    BasicChip(
+        modifier = modifier,
+        label = date,
+        containerColor = AppTheme.color.surface,
+        contentColor = contentColor,
+        leadingIcon = {
+            Icon(
+                painter = painterResource(R.drawable.date_icon),
+                contentDescription = "calendar icon",
+                tint = contentColor
+            )
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DateChipPreview() {
+    DateChip(
+        date = "12-03-2025"
+    )
+}

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/task_card/TaskItemCard.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/task_card/TaskItemCard.kt
@@ -1,0 +1,127 @@
+package com.amsterdam.cutetudee.presentation.component.task_card
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.amsterdam.cutetudee.R
+import com.amsterdam.cutetudee.presentation.component.chip.DateChip
+import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityChip
+import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityUi
+import com.amsterdam.cutetudee.presentation.theme.AppTheme
+
+@Composable
+fun TaskItemCard(
+    taskItemUiState: TaskItemUiState,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .background(
+                color = AppTheme.color.surfaceHigh,
+                shape = RoundedCornerShape(16.dp)
+            )
+            .padding(
+                start = 4.dp, top = 4.dp, end = 12.dp, bottom = 12.dp
+            ),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        TaskItemHeader(
+            taskItemUiState = taskItemUiState,
+            showDate = taskItemUiState.date.isNotEmpty()
+        )
+        TaskItemInfo(
+            taskItemUiState = taskItemUiState,
+            showDescription = taskItemUiState.description.isNotEmpty()
+        )
+
+    }
+}
+
+@Composable
+private fun TaskItemHeader(
+    taskItemUiState: TaskItemUiState,
+    showDate: Boolean,
+    modifier: Modifier = Modifier,
+) {
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Image(
+                painter = taskItemUiState.categoryImage,
+                contentDescription = null,
+                modifier = Modifier.padding(12.dp)
+            )
+        }
+        Spacer(Modifier.weight(1f))
+        AnimatedVisibility(showDate) {
+            DateChip(taskItemUiState.date)
+        }
+        PriorityChip(
+            priorityUi = taskItemUiState.priorityUi,
+            isSelected = true
+        )
+    }
+}
+
+@Composable
+private fun TaskItemInfo(
+    taskItemUiState: TaskItemUiState,
+    showDescription: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(start = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = taskItemUiState.name,
+            color = AppTheme.color.body,
+            style = AppTheme.textStyle.label.large
+        )
+        AnimatedVisibility(showDescription) {
+            Text(
+                text = taskItemUiState.description,
+                color = AppTheme.color.hint,
+                style = AppTheme.textStyle.label.small,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TaskCardPreview() {
+    TaskItemCard(
+        taskItemUiState = TaskItemUiState(
+            categoryImage = painterResource(R.drawable.developer_icon),
+            priorityUi = PriorityUi.MEDIUM,
+            name = "Organize Study Desk",
+            description = "Review cell structure and functions for tomorrow, Review cell structure and functions for tomorrow",
+            date = "12-03-2025",
+        ),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+    )
+}

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/task_card/TaskItemUiState.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/task_card/TaskItemUiState.kt
@@ -1,0 +1,12 @@
+package com.amsterdam.cutetudee.presentation.component.task_card
+
+import androidx.compose.ui.graphics.painter.Painter
+import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityUi
+
+data class TaskItemUiState(
+    val categoryImage: Painter,
+    val priorityUi: PriorityUi = PriorityUi.LOW,
+    val name: String = "",
+    val description: String = "",
+    val date: String = ""
+)


### PR DESCRIPTION
## Description
This pull request introduces a new reusable `TaskCard` component for displaying task information.

---

## Changes Made
List the changes introduced in this pull request:

- `TaskItemCard.kt`: Created the primary TaskItemCard composable, which is composed of:
     - `TaskItemHeader`: Displays the category icon, DateChip, and PriorityChip.
     - `TaskItemInfo`: Displays the task name and a collapsible description.

- `TaskItemUiState.kt`: Added a dedicated data class to hold the UI state for the task card, making the component easy to manage and preview.
- `DateChip.kt`: Created a new, reusable DateChip component with a calendar icon to consistently display dates.

---

## Screenshots
<img width="647" alt="Screenshot 2025-06-17 at 10 36 09" src="https://github.com/user-attachments/assets/293a080d-0838-408e-b509-936fe08d34e3" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---

## Additional Comments
You may notice the color of the icon is a little bit bright than the design. The solution for that is referenced [here](https://github.com/Amsterdam-Team/The-Cute-Tudee/pull/48) once it merged it'll take its normal color