### PR TITLE
Rotterdam- Add CustomPreview

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/CustomPreview.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/CustomPreview.kt
@@ -1,0 +1,44 @@
+package com.amsterdam.cutetudee.presentation
+
+import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.amsterdam.cutetudee.presentation.theme.CuteTudeeTheme
+
+@Preview(
+    name = "Light Theme - English",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    locale = "en",
+)
+@Preview(
+    name = "Dark Theme - English",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    locale = "en",
+)
+@Preview(
+    name = "Light Theme - Arabic",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    locale = "ar",
+)
+@Preview(
+    name = "Dark Theme - Arabic",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    locale = "ar",
+)
+annotation class ThemeAndLocalePreviews
+
+@Composable
+fun CustomPreview(content: @Composable () -> Unit) {
+    CuteTudeeTheme(isDarkTheme = isSystemInDarkTheme()) {
+        content()
+    }
+}

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/utils/CustomPreview.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/utils/CustomPreview.kt
@@ -1,10 +1,7 @@
-package com.amsterdam.cutetudee.presentation
+package com.amsterdam.cutetudee.presentation.utils
 
 import android.content.res.Configuration
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.amsterdam.cutetudee.presentation.theme.CuteTudeeTheme
 
 @Preview(
     name = "Light Theme - English",
@@ -35,10 +32,3 @@ import com.amsterdam.cutetudee.presentation.theme.CuteTudeeTheme
     locale = "ar",
 )
 annotation class ThemeAndLocalePreviews
-
-@Composable
-fun CustomPreview(content: @Composable () -> Unit) {
-    CuteTudeeTheme(isDarkTheme = isSystemInDarkTheme()) {
-        content()
-    }
-}


### PR DESCRIPTION
# Pull Request Template

## Description
Added `CustomPreview` with annotation `ThemeAndLocalePreviews` to be able to test any `Composable` on Light & Dark theme and on English & Arabic

---

## Changes Made
List the changes introduced in this pull request:

- Added `CustomPreview`

---

## How To Use

```
@ThemeAndLocalePreviews
@Composable
private fun YourPreview() {
    CuteTudeeTheme{
        YourComposable()
    }
}
```

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---

## Additional Comments
Add any additional information or context about the pull request here.