### PR TITLE
Rotterdam- remove redundant dismiss logic in ConfirmationBottomSheet

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/ConfirmationBottomSheet.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/ConfirmationBottomSheet.kt
@@ -6,14 +6,11 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.presentation.utils.ThemeAndLocalePreviews
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,23 +29,11 @@ fun ConfirmationBottomSheet(
         skipPartiallyExpanded = true,
         confirmValueChange = { true }
     )
-    val coroutineScope = rememberCoroutineScope()
-    val dismissBottomSheet = remember {
-        {
-            coroutineScope.launch {
-                sheetState.hide()
-            }.invokeOnCompletion {
-                if (!sheetState.isVisible) {
-                    onDismiss()
-                }
-            }
-        }
-    }
 
     if (isVisible) {
         CustomBottomSheet(
             modifier = modifier,
-            onDismissRequest = { dismissBottomSheet() },
+            onDismissRequest = onDismiss,
             sheetState = sheetState
         ) {
             Column(
@@ -64,11 +49,9 @@ fun ConfirmationBottomSheet(
                 ConfirmationButtonsContainer(
                     onAction = {
                         onAction()
-                        dismissBottomSheet()
                     },
                     onCancel = {
                         onCancel()
-                        dismissBottomSheet()
                     },
                     onActionText = onActionText,
                     onCancelText = onCancelText


### PR DESCRIPTION
## Description
 Remove redundant dismiss logic in ConfirmationBottomSheet

The dismiss logic was already handled by the `onDismissRequest` of the `CustomBottomSheet`. This commit removes the redundant manual dismiss logic.

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- x] Commit messages should follow the atomic commits convention.

---