### PR TITLE
Rotterdam- Fix mode switcher state

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -47,8 +47,8 @@ class HomeViewModel(
     }
 
     private fun loadHomeScreenStates() {
+        _homeState.update { it.copy(isLoading = true) }
         tryToExecute {
-            _homeState.update { it.copy(isLoading = true) }
             appSettingsService.getThemeMode().collectLatest { mode ->
                 val isDarkMode = mode == ThemeMode.DARK
                 observeHomeStateChanges(isDarkMode)


### PR DESCRIPTION
## Description
The `isLoading` state update in `loadHomeScreenStates` is moved outside the `tryToExecute` block. This ensures the loading state is set immediately before the asynchronous operation begins, providing a more accurate UI representation.

---

## Changes Made
List the changes introduced in this pull request:

- `isLoading` state update is moved out of the `tryToExecute` block

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---

## Additional comment
**I hope this doesn't break again🙃**