### PR TITLE
Den Haag- Make task item clickable in home screen

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeEffect.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeEffect.kt
@@ -5,11 +5,13 @@ sealed class HomeEffect {
 
     data object ShowTaskEditedFailedSnackBar : HomeEffect()
 
+    data object ShowTaskStatusFailedToEditSnackBar : HomeEffect()
+
+    data object ShowTaskStatusEditedSuccessfullySnackBar : HomeEffect()
+
     data object ShowTaskAddedSuccessfullySnackBar : HomeEffect()
 
     data object ShowTaskAddedFailedSnackBar : HomeEffect()
 
-    data object ShowFailedToLoadTaskSnackBar : HomeEffect()
-
-    data object ShowFailedToLoadCategoriesSnackBar : HomeEffect()
+    data object ShowLoadDataFailedSnackBar : HomeEffect()
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeEffect.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeEffect.kt
@@ -8,4 +8,8 @@ sealed class HomeEffect {
     data object ShowTaskAddedSuccessfullySnackBar : HomeEffect()
 
     data object ShowTaskAddedFailedSnackBar : HomeEffect()
+
+    data object ShowFailedToLoadTaskSnackBar : HomeEffect()
+
+    data object ShowFailedToLoadCategoriesSnackBar : HomeEffect()
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeMapper.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeMapper.kt
@@ -21,6 +21,7 @@ fun Pair<List<Task>, List<Category>>.toHomeUiState(): HomeUiState {
     fun Task.toTaskDetails(): HomeUiState.TaskDetails {
         val category = categories.find { it.id == categoryId }
         return HomeUiState.TaskDetails(
+            id = id.toString(),
             icon = category?.image?.toUri() ?: Uri.EMPTY,
             title = title,
             description = description.orEmpty(),

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -115,7 +115,7 @@ fun HomeScreen(
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun HomeScreenContent(
+private fun HomeScreenContent(
     homeUiState: HomeUiState,
     homeInteraction: HomeScreenInteraction,
     onNavigateToTaskScreen: (TaskStatusUi) -> Unit,
@@ -254,7 +254,7 @@ fun HomeScreenContent(
 }
 
 @Composable
-fun ShowEditTaskBottomSheet(
+private fun ShowEditTaskBottomSheet(
     addEditTaskInteractionListener: AddEditTaskInteractionListener,
     homeUiState: HomeUiState
 ) {
@@ -276,7 +276,7 @@ fun ShowEditTaskBottomSheet(
 
 @OptIn(ExperimentalUuidApi::class)
 @Composable
-fun ShowAddTaskBottomSheet(
+private fun ShowAddTaskBottomSheet(
     homeUiState: HomeUiState,
     addEditTaskInteractionListener: AddEditTaskInteractionListener
 ) {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -135,6 +135,12 @@ fun HomeScreenContent(
             iconDescription = stringResource(R.string.add_task),
         )
 
+        if (homeUiState.showEditTaskBottomSheet) {
+            ShowEditTaskBottomSheet(
+                addEditTaskInteractionListener = addEditInteractionListener,
+                homeUiState = homeUiState
+            )
+        }
         if (homeUiState.showAddTaskBottomSheet) {
             ShowAddTaskBottomSheet(
                 addEditTaskInteractionListener = addEditInteractionListener,
@@ -243,6 +249,27 @@ fun HomeScreenContent(
     }
 }
 
+@Composable
+fun ShowEditTaskBottomSheet(
+    addEditTaskInteractionListener: AddEditTaskInteractionListener,
+    homeUiState: HomeUiState
+) {
+    AddOrEditTaskBottomSheet(
+        taskAction = AddEditTaskUiState.TaskAction.EDIT,
+        modifier = Modifier,
+        interactionListener = addEditTaskInteractionListener,
+        taskName = homeUiState.addEditTaskUiState.taskName,
+        taskDescription = homeUiState.addEditTaskUiState.description,
+        date = homeUiState.addEditTaskUiState.date,
+        dateInMillis = homeUiState.addEditTaskUiState.dateInMillis,
+        priority = homeUiState.addEditTaskUiState.priority,
+        selectedCategoryId = homeUiState.addEditTaskUiState.selectedCategoryId,
+        categories = homeUiState.addEditTaskUiState.categories,
+        isLoading = homeUiState.addEditTaskUiState.isLoading,
+        isEnabled = homeUiState.addEditTaskUiState.isEnabled,
+    )
+}
+
 @OptIn(ExperimentalUuidApi::class)
 @Composable
 fun ShowAddTaskBottomSheet(
@@ -296,8 +323,15 @@ private fun HomeScreenPreview() {
                 override fun onTaskClicked(taskId: String) {}
 
                 override fun onDismissTaskDetailsBottomSheet() {}
-
-                override fun onEditTaskClicked() {}
+                override fun onEditTaskClicked(
+                    id: String,
+                    name: String,
+                    description: String,
+                    date: String,
+                    priority: PriorityUi,
+                    selectedCategoryId: String
+                ) {
+                }
 
                 override fun onDismissEditBottomSheet() {}
 

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -23,21 +23,23 @@ import androidx.compose.ui.zIndex
 import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.domain.entity.Task
 import com.amsterdam.cutetudee.presentation.LocalNavController
+import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsBottomSheet
+import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsUiState
 import com.amsterdam.cutetudee.presentation.component.CustomFloatingActionButton
 import com.amsterdam.cutetudee.presentation.component.LoadingIndicator
 import com.amsterdam.cutetudee.presentation.component.NoTasksContainer
+import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityUi
 import com.amsterdam.cutetudee.presentation.component.chip.tast_status.TaskStatusUi
+import com.amsterdam.cutetudee.presentation.component.custom_padding.bottomNavigationBarPadding
 import com.amsterdam.cutetudee.presentation.component.custom_snack_bar.CustomSnackBarStatus
-import com.amsterdam.cutetudee.presentation.model.TaskUi
 import com.amsterdam.cutetudee.presentation.navigation.Screen
-import com.amsterdam.cutetudee.presentation.screens.home.component.OverlayBoxContent
-import com.amsterdam.cutetudee.presentation.screens.home.component.TaskSection
-import com.amsterdam.cutetudee.presentation.screens.home.component.TopCuteTudeeAppBar
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractionListener
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import com.amsterdam.cutetudee.presentation.screens.component.AddOrEditTaskBottomSheet
+import com.amsterdam.cutetudee.presentation.screens.home.component.OverlayBoxContent
+import com.amsterdam.cutetudee.presentation.screens.home.component.TaskSection
+import com.amsterdam.cutetudee.presentation.screens.home.component.TopCuteTudeeAppBar
 import com.amsterdam.cutetudee.presentation.theme.AppTheme
-import com.amsterdam.cutetudee.presentation.component.custom_padding.bottomNavigationBarPadding
 import com.amsterdam.cutetudee.presentation.utils.toStringFormatedDate
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.datetime.Clock
@@ -57,6 +59,9 @@ fun HomeScreen(
     val editedTaskSuccessfullyMessage = stringResource(R.string.edit_task_success)
     val failAddTask = stringResource(R.string.add_task_fail)
     val failEditTask = stringResource(R.string.edit_task_fail)
+    val failLoadTask = stringResource(R.string.load_task_fail)
+    val failLoadCategory = stringResource(R.string.load_category_fail)
+
     LaunchedEffect(homeViewModel.homeEffect) {
         homeViewModel.homeEffect.collectLatest {
             when (it) {
@@ -79,6 +84,16 @@ fun HomeScreen(
 
                 HomeEffect.ShowTaskEditedFailedSnackBar -> onShowSnackBar(
                     failEditTask,
+                    CustomSnackBarStatus.Failure,
+                )
+
+                HomeEffect.ShowFailedToLoadCategoriesSnackBar -> onShowSnackBar(
+                    failLoadCategory,
+                    CustomSnackBarStatus.Failure,
+                )
+
+                HomeEffect.ShowFailedToLoadTaskSnackBar -> onShowSnackBar(
+                    failLoadTask,
                     CustomSnackBarStatus.Failure,
                 )
             }
@@ -126,6 +141,16 @@ fun HomeScreenContent(
                 homeUiState = homeUiState
             )
         }
+        if (homeUiState.showTaskDetailsBottomSheet) {
+            if (homeUiState.selectedTask == null) return
+            val state = TaskDetailsUiState(homeUiState.selectedTask, false)
+            TaskDetailsBottomSheet(
+                taskDetailsState = state,
+                onMoveToNextStatus = homeInteraction::onMoveToNextStatus,
+                onEditClick = homeInteraction::onEditTaskClicked,
+                onDismissRequest = homeInteraction::onDismissTaskDetailsBottomSheet
+            )
+        }
         if (homeUiState.isLoading) {
             LoadingIndicator(
                 modifier =
@@ -171,6 +196,7 @@ fun HomeScreenContent(
                                     onNavigateToTaskScreen(TaskStatusUi.IN_PROGRESS)
                                 },
                                 modifier = Modifier,
+                                onTaskClick = homeInteraction::onTaskClicked,
                             )
                         }
                         item {
@@ -181,6 +207,7 @@ fun HomeScreenContent(
                                     onNavigateToTaskScreen(TaskStatusUi.TODO)
                                 },
                                 modifier = Modifier,
+                                onTaskClick = homeInteraction::onTaskClicked,
                             )
                         }
                         item {
@@ -191,6 +218,7 @@ fun HomeScreenContent(
                                     onNavigateToTaskScreen(TaskStatusUi.DONE)
                                 },
                                 modifier = Modifier,
+                                onTaskClick = homeInteraction::onTaskClicked,
                             )
                         }
                     } else {
@@ -265,7 +293,7 @@ private fun HomeScreenPreview() {
 
                 override fun onDismissAddBottomSheet() {}
 
-                override fun onTaskClicked(task: TaskUi) {}
+                override fun onTaskClicked(taskId: String) {}
 
                 override fun onDismissTaskDetailsBottomSheet() {}
 

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -59,8 +59,9 @@ fun HomeScreen(
     val editedTaskSuccessfullyMessage = stringResource(R.string.edit_task_success)
     val failAddTask = stringResource(R.string.add_task_fail)
     val failEditTask = stringResource(R.string.edit_task_fail)
-    val failLoadTask = stringResource(R.string.load_task_fail)
-    val failLoadCategory = stringResource(R.string.load_category_fail)
+    val failToEditTaskStatus= stringResource(R.string.edit_task_status_fail)
+    val failToLoadData = stringResource(R.string.load_data_fail)
+    val successToUpdateTaskStatus = stringResource(R.string.edit_task_status_success)
 
     LaunchedEffect(homeViewModel.homeEffect) {
         homeViewModel.homeEffect.collectLatest {
@@ -87,13 +88,16 @@ fun HomeScreen(
                     CustomSnackBarStatus.Failure,
                 )
 
-                HomeEffect.ShowFailedToLoadCategoriesSnackBar -> onShowSnackBar(
-                    failLoadCategory,
+                HomeEffect.ShowTaskStatusFailedToEditSnackBar -> onShowSnackBar(
+                    failToEditTaskStatus,
                     CustomSnackBarStatus.Failure,
                 )
-
-                HomeEffect.ShowFailedToLoadTaskSnackBar -> onShowSnackBar(
-                    failLoadTask,
+                HomeEffect.ShowTaskStatusEditedSuccessfullySnackBar -> onShowSnackBar(
+                    successToUpdateTaskStatus,
+                    CustomSnackBarStatus.Success,
+                )
+                HomeEffect.ShowLoadDataFailedSnackBar -> onShowSnackBar(
+                    failToLoadData,
                     CustomSnackBarStatus.Failure,
                 )
             }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -334,6 +334,8 @@ private fun HomeScreenPreview() {
                 }
 
                 override fun onDismissEditBottomSheet() {}
+                override fun onMoveToNextStatus(taskStatusUi: TaskStatusUi) {
+                }
 
                 override fun onSwitchTheme() {}
             },

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -55,49 +56,45 @@ fun HomeScreen(
 ) {
     val navController = LocalNavController.current
     val state by homeViewModel.homeState.collectAsState()
-    val addedTaskSuccessfullyMessage = stringResource(R.string.add_task_success)
-    val editedTaskSuccessfullyMessage = stringResource(R.string.edit_task_success)
-    val failAddTask = stringResource(R.string.add_task_fail)
-    val failEditTask = stringResource(R.string.edit_task_fail)
-    val failToEditTaskStatus= stringResource(R.string.edit_task_status_fail)
-    val failToLoadData = stringResource(R.string.load_data_fail)
-    val successToUpdateTaskStatus = stringResource(R.string.edit_task_status_success)
+    val context = LocalContext.current
 
     LaunchedEffect(homeViewModel.homeEffect) {
         homeViewModel.homeEffect.collectLatest {
             when (it) {
                 HomeEffect.ShowTaskAddedSuccessfullySnackBar ->
                     onShowSnackBar(
-                        addedTaskSuccessfullyMessage,
+                        context.getString(R.string.add_task_success),
                         CustomSnackBarStatus.Success,
                     )
 
                 HomeEffect.ShowTaskEditedSuccessfullySnackBar ->
                     onShowSnackBar(
-                        editedTaskSuccessfullyMessage,
+                        context.getString(R.string.edit_task_success),
                         CustomSnackBarStatus.Success,
                     )
 
                 HomeEffect.ShowTaskAddedFailedSnackBar -> onShowSnackBar(
-                    failAddTask,
+                    context.getString(R.string.add_task_fail),
                     CustomSnackBarStatus.Failure,
                 )
 
                 HomeEffect.ShowTaskEditedFailedSnackBar -> onShowSnackBar(
-                    failEditTask,
+                    context.getString(R.string.edit_task_fail),
                     CustomSnackBarStatus.Failure,
                 )
 
                 HomeEffect.ShowTaskStatusFailedToEditSnackBar -> onShowSnackBar(
-                    failToEditTaskStatus,
+                    context.getString(R.string.edit_task_status_fail),
                     CustomSnackBarStatus.Failure,
                 )
+
                 HomeEffect.ShowTaskStatusEditedSuccessfullySnackBar -> onShowSnackBar(
-                    successToUpdateTaskStatus,
+                    context.getString(R.string.edit_task_status_success),
                     CustomSnackBarStatus.Success,
                 )
+
                 HomeEffect.ShowLoadDataFailedSnackBar -> onShowSnackBar(
-                    failToLoadData,
+                    context.getString(R.string.load_data_fail),
                     CustomSnackBarStatus.Failure,
                 )
             }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreenInteraction.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreenInteraction.kt
@@ -12,7 +12,14 @@ interface HomeScreenInteraction {
 
     fun onDismissTaskDetailsBottomSheet()
 
-    fun onEditTaskClicked()
+    fun onEditTaskClicked(
+            id: String,
+            name: String,
+            description: String,
+            date: String,
+            priority: PriorityUi,
+            selectedCategoryId: String
+    )
 
     fun onDismissEditBottomSheet()
 

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreenInteraction.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreenInteraction.kt
@@ -1,13 +1,14 @@
 package com.amsterdam.cutetudee.presentation.screens.home
 
-import com.amsterdam.cutetudee.presentation.model.TaskUi
+import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityUi
+import com.amsterdam.cutetudee.presentation.component.chip.tast_status.TaskStatusUi
 
 interface HomeScreenInteraction {
     fun onAddTaskClicked()
 
     fun onDismissAddBottomSheet()
 
-    fun onTaskClicked(task: TaskUi)
+    fun onTaskClicked(taskId: String)
 
     fun onDismissTaskDetailsBottomSheet()
 

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreenInteraction.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreenInteraction.kt
@@ -23,5 +23,7 @@ interface HomeScreenInteraction {
 
     fun onDismissEditBottomSheet()
 
+    fun onMoveToNextStatus(taskStatusUi: TaskStatusUi)
+
     fun onSwitchTheme()
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeUiState.kt
@@ -37,6 +37,7 @@ data class HomeUiState(
     val addEditTaskUiState: AddEditTaskUiState = AddEditTaskUiState()
 ) {
     data class TaskDetails(
+        val id: String = "",
         val icon: Uri = Uri.EMPTY,
         val title: String = "",
         val description: String = "",

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.uuid.ExperimentalUuidApi
 
 class HomeViewModel(
     private val taskService: TaskService,
@@ -139,7 +140,14 @@ class HomeViewModel(
         _homeState.update { it.copy(showTaskDetailsBottomSheet = false, selectedTask = null) }
     }
 
-    override fun onEditTaskClicked() {
+    override fun onEditTaskClicked(
+        id: String,
+        name: String,
+        description: String,
+        date: String,
+        priority: PriorityUi,
+        selectedCategoryId: String
+    ) {
         if (_homeState.value.addEditTaskUiState.categories.isEmpty()) {
             loadCategories()
         }
@@ -147,7 +155,16 @@ class HomeViewModel(
             it.copy(
                 showTaskDetailsBottomSheet = false,
                 showEditTaskBottomSheet = true,
-                selectedTask = it.selectedTask,
+                addEditTaskUiState = AddEditTaskUiState(
+                    id = id,
+                    taskName = name,
+                    description = description,
+                    date = date,
+                    priority = priority,
+                    selectedCategoryId = selectedCategoryId,
+                    categories = _homeState.value.addEditTaskUiState.categories,
+                    taskAction = AddEditTaskUiState.TaskAction.EDIT
+                )
             )
         }
     }
@@ -330,6 +347,7 @@ class HomeViewModel(
                         )
                     }
             } catch (e: Exception) {
+                _homeEffect.emit(HomeEffect.ShowFailedToLoadCategoriesSnackBar)
             }
         }
     }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -9,8 +9,14 @@ import com.amsterdam.cutetudee.domain.service.AppSettingsService
 import com.amsterdam.cutetudee.domain.service.CategoryService
 import com.amsterdam.cutetudee.domain.service.TaskService
 import com.amsterdam.cutetudee.domain.utils.ThemeMode
+import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityUi
 import com.amsterdam.cutetudee.presentation.component.chip.priority.toPriorityUi
-import com.amsterdam.cutetudee.presentation.model.TaskUi
+import com.amsterdam.cutetudee.presentation.component.chip.tast_status.TaskStatusUi
+import com.amsterdam.cutetudee.presentation.component.chip.tast_status.toTaskStatus
+import com.amsterdam.cutetudee.presentation.model.toCategoryUi
+import com.amsterdam.cutetudee.presentation.model.toTask
+import com.amsterdam.cutetudee.presentation.model.toTaskUi
+import com.amsterdam.cutetudee.presentation.screens.categoryDetails.toUuid
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractionListener
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toAddEditCategoryUiState
@@ -110,8 +116,23 @@ class HomeViewModel(
         _homeState.update { it.copy(showAddTaskBottomSheet = false) }
     }
 
-    override fun onTaskClicked(task: TaskUi) {
-        _homeState.update { it.copy(showTaskDetailsBottomSheet = true, selectedTask = task) }
+    @OptIn(ExperimentalUuidApi::class)
+    override fun onTaskClicked(taskId: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val task = taskService.getTaskById(taskId.toUuid())
+                val category = categoryService.getCategoryById(task.categoryId)
+                val mappedTask = task.toTaskUi(category.toCategoryUi())
+                _homeState.update {
+                    it.copy(
+                        showTaskDetailsBottomSheet = true,
+                        selectedTask = mappedTask
+                    )
+                }
+            } catch (e: Exception) {
+                _homeEffect.emit(HomeEffect.ShowFailedToLoadTaskSnackBar)
+            }
+        }
     }
 
     override fun onDismissTaskDetailsBottomSheet() {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -54,12 +54,17 @@ class HomeViewModel(
     }
 
     private fun loadHomeScreenStates() {
-        tryToExecute {
-            _homeState.update { it.copy(isLoading = true) }
-            appSettingsService.getThemeMode().collectLatest { mode ->
-                val isDarkMode = mode == ThemeMode.DARK
-                observeHomeStateChanges(isDarkMode)
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                _homeState.update { it.copy(isLoading = true) }
+                appSettingsService.getThemeMode().collectLatest { mode ->
+                    val isDarkMode = mode == ThemeMode.DARK
+                    observeHomeStateChanges(isDarkMode)
+                }
+            } catch (e: Exception) {
+                _homeEffect.emit(HomeEffect.ShowLoadDataFailedSnackBar)
             }
+
         }
     }
 
@@ -96,21 +101,18 @@ class HomeViewModel(
             else -> MoodState.STAY_WORKING
         }
 
-    private fun tryToExecute(function: suspend () -> Unit) {
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                function()
-            } catch (e: Exception) {
-                _homeEffect.emit(HomeEffect.ShowTaskEditedFailedSnackBar)
-            }
-        }
-    }
-
     override fun onAddTaskClicked() {
         if (_homeState.value.addEditTaskUiState.categories.isEmpty()) {
             loadCategories()
         }
-        _homeState.update { it.copy(showAddTaskBottomSheet = true) }
+        _homeState.update {
+            it.copy(
+                showAddTaskBottomSheet = true,
+                addEditTaskUiState = it.addEditTaskUiState.copy(
+                    taskAction = AddEditTaskUiState.TaskAction.ADD
+                )
+            )
+        }
     }
 
     override fun onDismissAddBottomSheet() {
@@ -131,7 +133,7 @@ class HomeViewModel(
                     )
                 }
             } catch (e: Exception) {
-                _homeEffect.emit(HomeEffect.ShowFailedToLoadTaskSnackBar)
+                _homeEffect.emit(HomeEffect.ShowLoadDataFailedSnackBar)
             }
         }
     }
@@ -177,14 +179,19 @@ class HomeViewModel(
 
     @OptIn(ExperimentalUuidApi::class)
     override fun onMoveToNextStatus(taskStatusUi: TaskStatusUi) {
-        if (_homeState.value.selectedTask == null)  return
-        tryToExecute {
-            taskService.editTask(
-                _homeState.value.selectedTask!!
-                    .toTask()
-                    .copy(status = taskStatusUi.toTaskStatus()),
-            )
-            _homeState.update { it.copy(selectedTask = it.selectedTask?.copy(status = taskStatusUi)) }
+        if (_homeState.value.selectedTask == null) return
+        val updatedSelectedTask = _homeState.value.selectedTask!!.copy(status = taskStatusUi)
+        val taskToUpdate: Task = _homeState.value.selectedTask!!.toTask()
+            .copy(status = taskStatusUi.toTaskStatus())
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                taskService.editTask(taskToUpdate)
+                _homeState.update { it.copy(selectedTask = updatedSelectedTask) }
+                _homeEffect.emit(HomeEffect.ShowTaskStatusEditedSuccessfullySnackBar)
+            } catch (e: Exception) {
+                _homeEffect.emit(HomeEffect.ShowTaskStatusFailedToEditSnackBar)
+            }
         }
     }
 
@@ -354,28 +361,23 @@ class HomeViewModel(
             try {
                 categoryService.getAllCategories()
                     .collectLatest { categories ->
-                        updateUiState(
-                            categories,
-                            AddEditTaskUiState.TaskAction.ADD
-                        )
+                        updateUiState(categories)
                     }
             } catch (e: Exception) {
-                _homeEffect.emit(HomeEffect.ShowFailedToLoadCategoriesSnackBar)
+                _homeEffect.emit(HomeEffect.ShowLoadDataFailedSnackBar)
             }
         }
     }
 
     private fun updateUiState(
-        categories: List<Category>,
-        taskAction: AddEditTaskUiState.TaskAction
+        categories: List<Category>
     ) {
         _homeState.update { state ->
             val convertedCategories =
                 categories.map { category -> category.toAddEditCategoryUiState() }
             state.copy(
                 addEditTaskUiState = state.addEditTaskUiState.copy(
-                    categories = convertedCategories,
-                    taskAction = taskAction
+                    categories = convertedCategories
                 ),
             )
         }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -175,6 +175,19 @@ class HomeViewModel(
         }
     }
 
+    @OptIn(ExperimentalUuidApi::class)
+    override fun onMoveToNextStatus(taskStatusUi: TaskStatusUi) {
+        if (_homeState.value.selectedTask == null)  return
+        tryToExecute {
+            taskService.editTask(
+                _homeState.value.selectedTask!!
+                    .toTask()
+                    .copy(status = taskStatusUi.toTaskStatus()),
+            )
+            _homeState.update { it.copy(selectedTask = it.selectedTask?.copy(status = taskStatusUi)) }
+        }
+    }
+
     override fun onSwitchTheme() {
         val isDarkMode = !homeState.value.isDarkMode
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -125,11 +125,11 @@ class HomeViewModel(
             try {
                 val task = taskService.getTaskById(taskId.toUuid())
                 val category = categoryService.getCategoryById(task.categoryId)
-                val mappedTask = task.toTaskUi(category.toCategoryUi())
+                val taskUi = task.toTaskUi(category.toCategoryUi())
                 _homeState.update {
                     it.copy(
                         showTaskDetailsBottomSheet = true,
-                        selectedTask = mappedTask
+                        selectedTask = taskUi
                     )
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -55,7 +55,7 @@ class HomeViewModel(
     }
 
     private fun loadHomeScreenStates() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 _homeState.update { it.copy(isLoading = true) }
                 appSettingsService.getThemeMode().collectLatest { mode ->
@@ -122,7 +122,7 @@ class HomeViewModel(
 
     @OptIn(ExperimentalUuidApi::class)
     override fun onTaskClicked(taskId: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 val task = taskService.getTaskById(taskId.toUuid())
                 val category = categoryService.getCategoryById(task.categoryId)
@@ -185,7 +185,7 @@ class HomeViewModel(
         val taskToUpdate: Task = _homeState.value.selectedTask!!.toTask()
             .copy(status = taskStatusUi.toTaskStatus())
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 taskService.editTask(taskToUpdate)
                 _homeState.update { it.copy(selectedTask = updatedSelectedTask) }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/TaskSection.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/TaskSection.kt
@@ -20,6 +20,7 @@ import com.amsterdam.cutetudee.presentation.screens.home.HomeUiState.TaskDetails
 fun TaskSection(
     title: String,
     tasks: List<TaskDetails>,
+    onTaskClick: (String) -> Unit,
     onNavigateToTaskScreen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -48,6 +49,7 @@ fun TaskSection(
                     description = taskItem.description,
                     modifier =
                         Modifier.width((LocalConfiguration.current.screenWidthDp - 40).dp),
+                    onClick = { onTaskClick(taskItem.id) },
                 )
             }
         }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/TaskSection.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/TaskSection.kt
@@ -62,7 +62,8 @@ fun TaskSection(
 private fun TaskSectionPreview(){
     TaskSection(
         title = "",
-        tasks =emptyList(),
+        tasks = emptyList(),
         onNavigateToTaskScreen = {},
+        onTaskClick = {},
     )
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -99,6 +99,7 @@
     <string name="delete_task_success">.تم حذف المهمة بنجاح</string>
     <string name="edit_category_success">.تم تعديل الفئة بنجاح</string>
     <string name="add_category_success">.تم إضافة الفئة بنجاح</string>
+    <string name="edit_task_status_success">.تم تعديل الحاله بنجاح</string>
 
     <!-- Confirmation Messages -->
     <string name="delete_description">هل أنت متأكد من المتابعة؟</string>
@@ -111,8 +112,12 @@
     <string name="edit_task_fail">لم يتم تعديل المهمة.</string>
     <string name="add_task_fail">لم يتم إضافة المهمة.</string>
 
+    <string name="edit_task_status_fail">لم يتم تعديل الحاله.</string>
+
     <string name="load_task_fail">لم يتم العثور على المهمة</string>
     <string name="load_category_fail">لم يتم العثور على الفئة</string>
+
+    <string name="load_data_fail">لم يتم العثور على البيانات</string>
 
     <string name="error_invalid_category_input">إدخال غير صالح للفئة</string>
     <string name="error_no_categories_found">لم يتم العثور على أي فئات</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -111,6 +111,9 @@
     <string name="edit_task_fail">لم يتم تعديل المهمة.</string>
     <string name="add_task_fail">لم يتم إضافة المهمة.</string>
 
+    <string name="load_task_fail">لم يتم العثور على المهمة</string>
+    <string name="load_category_fail">لم يتم العثور على الفئة</string>
+
     <string name="error_invalid_category_input">إدخال غير صالح للفئة</string>
     <string name="error_no_categories_found">لم يتم العثور على أي فئات</string>
     <string name="error_category_not_found">لم يتم العثور على الفئة</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,9 @@
     <string name="edit_task_fail">Failed To Edit Task.</string>
     <string name="add_task_fail">Failed To Add Task.</string>
 
+    <string name="load_task_fail">Failed To Load Task.</string>
+    <string name="load_category_fail">Failed To Load Category.</string>
+
     <string name="error_invalid_category_input">Invalid category input</string>
     <string name="error_no_categories_found">No categories found</string>
     <string name="error_category_not_found">Category not found</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="delete_task_success">Task Deleted successfully.</string>
     <string name="edit_category_success">Category Edited successfully.</string>
     <string name="add_category_success">Category Added successfully.</string>
+    <string name="edit_task_status_success">Status Edited successfully.</string>
 
     <!-- Confirmation Messages -->
     <string name="delete_description">Are you sure you want to continue?</string>
@@ -108,8 +109,12 @@
     <string name="edit_task_fail">Failed To Edit Task.</string>
     <string name="add_task_fail">Failed To Add Task.</string>
 
+    <string name="edit_task_status_fail">Failed To Edit Status.</string>
+
     <string name="load_task_fail">Failed To Load Task.</string>
     <string name="load_category_fail">Failed To Load Category.</string>
+
+    <string name="load_data_fail">Failed To Load Data.</string>
 
     <string name="error_invalid_category_input">Invalid category input</string>
     <string name="error_no_categories_found">No categories found</string>


### PR DESCRIPTION
# Pull Request Template

## Description
Make task item clickable in home screen to see task details and make some actions like (edit task, edit status)

---

## Changes Made

- Implement clickable action in task item.
- Show task details after clicking the item.
- Update task status after clicking on status.
- Show edit bottom sheet after clicking on edit.
- Handle errors and effects on the screens to show snack bar after an action

---

## Screenshots (if applicable)

---

## Checklist

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---

## Additional Comments
- There is a point that when I update the task status the bottom sheet of task details closes.