### PR TITLE
Rotterdam refactor/fix handle past days in date

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/CustomDatePickerDialog.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/CustomDatePickerDialog.kt
@@ -45,7 +45,11 @@ fun CustomDatePickerDialog(
     val datePickerState = rememberDatePickerState(
         initialSelectedDateMillis = initialSelectedDateMillis
             ?: getCurrentDateInMillis(),
-        selectableDates = selectableDates ?: object : SelectableDates {}
+        selectableDates = selectableDates ?: object : SelectableDates {
+            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                return utcTimeMillis >= getCurrentDateInMillis()
+            }
+        }
     )
 
     val currentHeadlineText = remember(datePickerState.selectedDateMillis) {
@@ -199,8 +203,13 @@ private fun CustomDatePickerDialogPreview() {
 
         val datePickerState = rememberDatePickerState(
             initialSelectedDateMillis = 1718744400000,
-            selectableDates = object : SelectableDates {}
+            selectableDates = object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                    return utcTimeMillis >= getCurrentDateInMillis()
+                }
+            }
         )
+
         selectedDateMillis?.let { millis ->
             val dateString = "19 June 25"
             Text("Selected: $dateString", style = MaterialTheme.typography.bodyLarge)


### PR DESCRIPTION
# Pull Request Template

## Description
Handle the past days while choosing a day in calender disable or prevent selection of any date that is before today.
---

## Changes Made
List the changes introduced in this pull request:

-
-
-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [ ] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [ ] Commit messages should follow the atomic commits convention.

---

## Additional Comments
Add any additional information or context about the pull request here.