### PR TITLE
Rotterdam- Fix add task default date

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
@@ -21,8 +21,10 @@ import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractio
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toAddEditCategoryUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toTask
+import com.amsterdam.cutetudee.presentation.utils.getDateInMillisFromLocalDate
 import com.amsterdam.cutetudee.presentation.utils.getLocalDateFromMillis
 import com.amsterdam.cutetudee.presentation.utils.getStringDateFromMillis
+import com.amsterdam.cutetudee.presentation.utils.toStringFormatedDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -68,7 +70,16 @@ class TasksViewModel(
         if (_taskUiState.value.addEditTaskUiState.categories.isEmpty()) {
             loadCategories()
         }
-        _taskUiState.update { it.copy(isAddTaskBottomSheetVisible = true) }
+        _taskUiState.update {
+            it.copy(
+                isAddTaskBottomSheetVisible = true,
+                addEditTaskUiState =
+                    it.addEditTaskUiState.copy(
+                        date = it.currentDate.toStringFormatedDate(),
+                        dateInMillis = it.currentDate.getDateInMillisFromLocalDate(),
+                    ),
+            )
+        }
     }
 
     override fun onTabChange(taskStatusUi: TaskStatusUi) {


### PR DESCRIPTION
## Description
Update when the "Add Task" bottom sheet is opened, the date field will now be pre-filled with the currently selected date. This streamlines the task creation process by defaulting to the relevant date.

---

## Changes Made
List the changes introduced in this pull request:

- Add task state set to selected date in task screen when add new task

---

## ScreenRecord

[Screencast from 2025-06-26 17-31-52.webm](https://github.com/user-attachments/assets/9fef2ad9-32a8-4c9c-a57d-f18402fde8c5)


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---