### PR TITLE
Utrecht refactor/improve viewmodel testability

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/di/ViewModelModule.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/di/ViewModelModule.kt
@@ -8,12 +8,13 @@ import com.amsterdam.cutetudee.presentation.screens.onBoarding.OnBoardingViewMod
 import com.amsterdam.cutetudee.presentation.screens.splash.SplashViewModel
 import com.amsterdam.cutetudee.presentation.screens.tasks.TasksViewModel
 import com.amsterdam.cutetudee.presentation.utils.dispatcher.DefaultDispatcherProvider
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val viewModelModule = module {
-    singleOf(::DefaultDispatcherProvider)
+    singleOf<DispatcherProvider>(::DefaultDispatcherProvider)
     viewModelOf(::OnBoardingViewModel)
     viewModelOf(::SplashViewModel)
     viewModelOf(::TasksViewModel)

--- a/app/src/main/java/com/amsterdam/cutetudee/di/ViewModelModule.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/di/ViewModelModule.kt
@@ -7,10 +7,13 @@ import com.amsterdam.cutetudee.presentation.screens.home.HomeViewModel
 import com.amsterdam.cutetudee.presentation.screens.onBoarding.OnBoardingViewModel
 import com.amsterdam.cutetudee.presentation.screens.splash.SplashViewModel
 import com.amsterdam.cutetudee.presentation.screens.tasks.TasksViewModel
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DefaultDispatcherProvider
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val viewModelModule = module {
+    singleOf(::DefaultDispatcherProvider)
     viewModelOf(::OnBoardingViewModel)
     viewModelOf(::SplashViewModel)
     viewModelOf(::TasksViewModel)

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.amsterdam.cutetudee.domain.entity.Category
 import com.amsterdam.cutetudee.domain.service.CategoryService
 import com.amsterdam.cutetudee.presentation.screens.category.mappers.toCategoryItemUiState
-import kotlinx.coroutines.Dispatchers
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +21,7 @@ import kotlin.uuid.ExperimentalUuidApi
 @OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
 class CategoryViewModel(
     private val categoryService: CategoryService,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel(), CategoryInteractionListener, CategoryAddInteractionListener {
 
     private val _state = MutableStateFlow(CategoryScreenUiState())
@@ -34,7 +35,7 @@ class CategoryViewModel(
     }
 
     private fun sendNewEffect(effect: CategoryEffect) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             _effect.emit(effect)
         }
     }
@@ -44,7 +45,7 @@ class CategoryViewModel(
     }
 
     private fun loadCategories() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 categoryService.getAllCategories().collectLatest { category ->
                     updateState {
@@ -95,7 +96,7 @@ class CategoryViewModel(
                 )
             )
         }
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 categoryService.addCategory(
                     Category(

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/categoryDetails/CategoryDetailsViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/categoryDetails/CategoryDetailsViewModel.kt
@@ -12,7 +12,7 @@ import com.amsterdam.cutetudee.domain.entity.Task
 import com.amsterdam.cutetudee.domain.service.CategoryService
 import com.amsterdam.cutetudee.domain.service.TaskService
 import com.amsterdam.cutetudee.presentation.navigation.Screen
-import kotlinx.coroutines.Dispatchers
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -27,6 +27,7 @@ class CategoryDetailsViewModel(
     savedStateHandle: SavedStateHandle,
     private val taskService: TaskService,
     private val categoryService: CategoryService,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel(), CategoryDetailsInteractionListener, CategoryEditInteractionListener,
     CategoryDeleteConfirmationInteractionListener {
 
@@ -46,7 +47,7 @@ class CategoryDetailsViewModel(
     }
 
     private fun sendNewEffect(effect: CategoryDetailsEffect) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             _effect.emit(effect)
         }
     }
@@ -59,7 +60,7 @@ class CategoryDetailsViewModel(
     private fun getCategoryDetails() {
         updateState { it.copy(isLoading = true) }
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 val tasks = taskService.getTasksByCategoryId(categoryId.toUuid()).first()
                 val category = categoryService.getAllCategories().first().first(::onFilterById)
@@ -92,7 +93,7 @@ class CategoryDetailsViewModel(
     }
 
     override fun onEditOptionClicked(name: String, uri: Uri) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 val selectedUriImage =
                     state.value.categoryBottomSheetState.image.takeIf { it != Uri.EMPTY } ?: uri
@@ -145,7 +146,7 @@ class CategoryDetailsViewModel(
     @OptIn(ExperimentalUuidApi::class)
     override fun onSaveCategoryClicked() {
         updateLoadingState()
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 categoryService.addCategory(
                     Category(
@@ -192,7 +193,7 @@ class CategoryDetailsViewModel(
 
     override fun onDeleteConfirmationClicked() {
         updateLoadingState()
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 categoryService.deleteCategory(state.value.categoryItemUiState.id.toUuid())
                 updateState {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -15,8 +15,8 @@ import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractio
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toAddEditCategoryUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toTask
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import com.amsterdam.cutetudee.presentation.utils.getStringDateFromMillis
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -33,7 +33,8 @@ import kotlinx.datetime.toLocalDateTime
 class HomeViewModel(
     private val taskService: TaskService,
     private val categoryService: CategoryService,
-    private val appSettingsService: AppSettingsService
+    private val appSettingsService: AppSettingsService,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel(),
     HomeScreenInteraction, AddEditTaskInteractionListener {
     private val _homeState = MutableStateFlow(HomeUiState())
@@ -90,7 +91,7 @@ class HomeViewModel(
         }
 
     private fun tryToExecute(function: suspend () -> Unit) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 function()
             } catch (e: Exception) {
@@ -139,7 +140,7 @@ class HomeViewModel(
 
     override fun onSwitchTheme() {
         val isDarkMode = !homeState.value.isDarkMode
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 appSettingsService.setThemeMode(isDarkMode.toThemeMode())
                 _homeState.update { it.copy(isDarkMode = isDarkMode) }
@@ -267,7 +268,7 @@ class HomeViewModel(
 
     private fun editTask() {
         updateIsLoading(true)
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 taskService.editTask(
                     _homeState.value.addEditTaskUiState.toTask()
@@ -283,7 +284,7 @@ class HomeViewModel(
 
     private fun addTask() {
         updateIsLoading(true)
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 taskService.addTask(
                     _homeState.value.addEditTaskUiState.toTask()
@@ -299,7 +300,7 @@ class HomeViewModel(
     }
 
     private fun loadCategories() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 categoryService.getAllCategories()
                     .collectLatest { categories ->

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/onBoarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/onBoarding/OnBoardingViewModel.kt
@@ -3,14 +3,15 @@ package com.amsterdam.cutetudee.presentation.screens.onBoarding
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.cutetudee.domain.service.AppSettingsService
-import kotlinx.coroutines.Dispatchers
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class OnBoardingViewModel(
-    private val appSettingsService: AppSettingsService
+    private val appSettingsService: AppSettingsService,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel(), OnBoardingInteractionListener {
     private val _state = MutableStateFlow(OnboardingUiState())
     val state: StateFlow<OnboardingUiState> = _state
@@ -23,7 +24,7 @@ class OnBoardingViewModel(
     }
 
     private fun tryToExecute(function: suspend () -> Unit) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 function()
             } catch (e: Exception) {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/splash/SplashViewModel.kt
@@ -3,13 +3,14 @@ package com.amsterdam.cutetudee.presentation.screens.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.cutetudee.domain.service.AppSettingsService
-import kotlinx.coroutines.Dispatchers
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class SplashViewModel(
-    private val appSettingsService: AppSettingsService
+    private val appSettingsService: AppSettingsService,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<Boolean?>(null)
@@ -23,7 +24,7 @@ class SplashViewModel(
     }
 
     private fun tryToExecute(function: suspend () -> Unit) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 function()
             } catch (e: Exception) {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
@@ -21,9 +21,9 @@ import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractio
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toAddEditCategoryUiState
 import com.amsterdam.cutetudee.presentation.screens.common.toTask
+import com.amsterdam.cutetudee.presentation.utils.dispatcher.DispatcherProvider
 import com.amsterdam.cutetudee.presentation.utils.getLocalDateFromMillis
 import com.amsterdam.cutetudee.presentation.utils.getStringDateFromMillis
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,7 +43,8 @@ import kotlin.uuid.ExperimentalUuidApi
 class TasksViewModel(
     savedStateHandle: SavedStateHandle,
     private val taskService: TaskService,
-    private val categoryService: CategoryService
+    private val categoryService: CategoryService,
+    private val dispatcherProvider: DispatcherProvider
 ) : ViewModel(),
     TasksInteraction, AddEditTaskInteractionListener {
     private val _taskUiState = MutableStateFlow(TasksUiState())
@@ -216,7 +217,7 @@ class TasksViewModel(
     }
 
     private fun tryToExecute(function: suspend () -> Unit) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 function()
             } catch (_: Exception) {
@@ -343,7 +344,7 @@ class TasksViewModel(
 
     private fun editTask() {
         updateIsLoading(true)
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 taskService.editTask(
                     _taskUiState.value.addEditTaskUiState.toTask()
@@ -359,7 +360,7 @@ class TasksViewModel(
 
     private fun addTask() {
         updateIsLoading(true)
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 taskService.addTask(
                     _taskUiState.value.addEditTaskUiState.toTask()
@@ -375,7 +376,7 @@ class TasksViewModel(
     }
 
     private fun loadCategories() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(dispatcherProvider.IO) {
             try {
                 categoryService.getAllCategories()
                     .collectLatest { categories ->


### PR DESCRIPTION
# Pull Request Template
improve viewmodel testability
## Description

Refactor ViewModels to depend on a Dispatcher abstraction instead of using Dispatchers directly. This allows injecting a standard test dispatcher during unit testing, making tests more predictable and easier to control.

---

## Changes Made
List the changes introduced in this pull request:

- Refactor ViewModels to depend on a Dispatcher abstraction instead of using Dispatchers directly

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---

## Additional Comments
Add any additional information or context about the pull request here.