### PR TITLE
Utrecht fix/save task status when editing

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import com.amsterdam.cutetudee.domain.service.CategoryService
 import com.amsterdam.cutetudee.domain.service.TaskService
 import com.amsterdam.cutetudee.domain.utils.ThemeMode
 import com.amsterdam.cutetudee.presentation.component.chip.priority.toPriorityUi
+import com.amsterdam.cutetudee.presentation.component.chip.tast_status.toTaskStatus
 import com.amsterdam.cutetudee.presentation.model.TaskUi
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractionListener
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
@@ -127,6 +128,10 @@ class HomeViewModel(
                 showTaskDetailsBottomSheet = false,
                 showEditTaskBottomSheet = true,
                 selectedTask = it.selectedTask,
+                addEditTaskUiState = it.addEditTaskUiState.copy(
+                    status = homeState.value.selectedTask?.status?.toTaskStatus()
+                        ?: Task.Status.TODO
+                )
             )
         }
     }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
@@ -181,7 +181,9 @@ class TasksViewModel(
                     priority = priority,
                     selectedCategoryId = selectedCategoryId,
                     categories = taskUiState.value.addEditTaskUiState.categories,
-                    taskAction = AddEditTaskUiState.TaskAction.EDIT
+                    taskAction = AddEditTaskUiState.TaskAction.EDIT,
+                    status = taskUiState.value.selectedTask?.status?.toTaskStatus()
+                        ?: Task.Status.TODO
                 )
             )
         }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes an issue where the task status is reset to the default status (ToDo) when editing. 

---

## Changes Made
List the changes introduced in this pull request:

- Modified the onEditTaskClicked function in both TasksViewModel.kt and HomeViewModel.kt to include the current task's status.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.
