### PR TITLE
Rotterdam- Fix home task grid

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/TaskItemCard.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/TaskItemCard.kt
@@ -105,8 +105,7 @@ fun TaskItemCard(
         contentAlignment = Alignment.Center,
         modifier =
             modifier
-                .fillMaxWidth()
-                .padding(top = 4.dp, bottom = 12.dp),
+                .fillMaxWidth(),
     ) {
         DeleteIcon(
             shape = cardShape,
@@ -133,7 +132,8 @@ fun TaskItemCard(
                             onClick()
                         },
                         role = Role.Button,
-                    ).padding(start = 4.dp, top = 4.dp, end = 12.dp, bottom = 12.dp),
+                    )
+                    .padding(start = 4.dp, top = 4.dp, end = 12.dp, bottom = 12.dp),
         ) {
             TaskItemHeader(
                 categoryImage = categoryImage,
@@ -160,7 +160,8 @@ private fun DeleteIcon(
                 .background(
                     color = AppTheme.color.errorVariant,
                     shape = shape,
-                ).padding(horizontal = 12.dp),
+                )
+                .padding(horizontal = 12.dp),
     ) {
         Icon(
             painter = painterResource(R.drawable.delete_icon),

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/TaskSection.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/TaskSection.kt
@@ -1,23 +1,21 @@
 package com.amsterdam.cutetudee.presentation.screens.home.component
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowColumn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.amsterdam.cutetudee.presentation.component.TaskItemCard
-import com.amsterdam.cutetudee.presentation.component.chip.tast_status.TaskStatusUi
 import com.amsterdam.cutetudee.presentation.screens.home.HomeUiState.TaskDetails
-import com.amsterdam.cutetudee.presentation.utils.ThemeAndLocalePreviews
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun TaskSection(
     title: String,
@@ -37,13 +35,17 @@ fun TaskSection(
             onClick = onNavigateToTaskScreen,
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
         )
-        LazyHorizontalGrid(
-            rows = GridCells.Fixed(2),
-            contentPadding = PaddingValues(horizontal = 16.dp),
+
+        FlowColumn(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.height(266.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier =
+                Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(start = 16.dp),
+            maxItemsInEachColumn = 2,
         ) {
-            items(tasks) { taskItem ->
+            tasks.forEach { taskItem ->
                 TaskItemCard(
                     categoryImage = taskItem.icon,
                     priorityUi = taskItem.taskPriority,
@@ -56,14 +58,4 @@ fun TaskSection(
             }
         }
     }
-}
-@Composable
-@ThemeAndLocalePreviews
-private fun TaskSectionPreview(){
-    TaskSection(
-        title = "",
-        tasks = emptyList(),
-        onNavigateToTaskScreen = {},
-        onTaskClick = {},
-    )
 }


### PR DESCRIPTION
## Description
Enhancing and fixing the home screen tasks grid.

---

## Changes Made
List the changes introduced in this pull request:

- In TaskItemCard.kt, the padding on the DeleteIcon was removed.
- In **TaskSection.kt**, `LazyHorizontalGrid` was replaced with `FlowColumn` for displaying tasks, and the horizontal scroll was enabled. Padding was adjusted for the new layout.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---