### PR TITLE
Rotterdam- Updated category grid to be adaptive

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/component/AddOrEditTaskBottomSheet.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/component/AddOrEditTaskBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.amsterdam.cutetudee.R
@@ -149,7 +150,8 @@ private fun CategorySection(
         modifier = Modifier.padding(vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
-        categoryItemUiStates.chunked(3).forEach {
+        val chunks = LocalConfiguration.current.screenWidthDp / 125
+        categoryItemUiStates.chunked(chunks).forEach {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(20.dp),
@@ -164,7 +166,7 @@ private fun CategorySection(
                         modifier = Modifier.weight(1f)
                     )
                 }
-                (1..(3 - it.size)).forEach { _ ->
+                (1..(chunks - it.size)).forEach { _ ->
                     Box(modifier = Modifier.weight(1f))
                 }
             }


### PR DESCRIPTION
## Description
Updated category grid to be adaptive in AddOrEditTaskBottomSheet.kt where count of category items in each row is calculated based on screen width / 125

---

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/5dcf8419-5a33-4598-b284-fa8b2b2b71f0)

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---