### PR TITLE
Rotterdam- Prevent User to Add Task In Past Dates

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksEffect.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksEffect.kt
@@ -7,4 +7,5 @@ sealed class TasksEffect {
     data object ShowSuccessEditTaskSnackBar : TasksEffect()
     data object ShowFailedAddTaskSnackBar : TasksEffect()
     data object ShowFailedEditTaskSnackBar : TasksEffect()
+    data object ShowFailedWrongDateTaskSnackBar : TasksEffect()
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksScreen.kt
@@ -3,11 +3,6 @@ package com.amsterdam.cutetudee.presentation.screens.tasks
 import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Easing
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -36,13 +31,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -53,6 +47,7 @@ import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.domain.entity.Task
 import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsBottomSheet
 import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsUiState
+import com.amsterdam.cutetudee.presentation.component.AddOrEditTaskBottomSheet
 import com.amsterdam.cutetudee.presentation.component.ConfirmationBottomSheet
 import com.amsterdam.cutetudee.presentation.component.CustomDatePickerDialog
 import com.amsterdam.cutetudee.presentation.component.CustomFloatingActionButton
@@ -66,7 +61,6 @@ import com.amsterdam.cutetudee.presentation.component.custom_snack_bar.CustomSna
 import com.amsterdam.cutetudee.presentation.model.TaskUi
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractionListener
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
-import com.amsterdam.cutetudee.presentation.component.AddOrEditTaskBottomSheet
 import com.amsterdam.cutetudee.presentation.theme.AppTheme
 import com.amsterdam.cutetudee.presentation.theme.CuteTudeeTheme
 import com.amsterdam.cutetudee.presentation.utils.ThemeAndLocalePreviews
@@ -75,7 +69,6 @@ import com.amsterdam.cutetudee.presentation.utils.getCurrentMonthDays
 import com.amsterdam.cutetudee.presentation.utils.monthDays
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.koinViewModel
 import java.time.format.TextStyle
@@ -88,42 +81,42 @@ fun TasksScreen(
     viewModel: TasksViewModel = koinViewModel()
 ) {
     val state by viewModel.taskUiState.collectAsState()
-    val successDeleteTask = stringResource(R.string.delete_task_success)
-    val successAddTask = stringResource(R.string.add_task_success)
-    val successEditTask = stringResource(R.string.edit_task_success)
-    val failAddTask = stringResource(R.string.add_task_fail)
-    val failEditTask = stringResource(R.string.edit_task_fail)
-    val unKnownErrorMessage = stringResource(R.string.error_unknown)
+    val context = LocalContext.current
     LaunchedEffect(Unit) {
         viewModel.effect.collectLatest {
             when (it) {
                 is TasksEffect.ShowSuccessDeleteTaskSnackBar -> onShowSnackBar(
-                    successDeleteTask,
+                    context.getString(R.string.delete_task_success),
                     CustomSnackBarStatus.Success
                 )
 
                 is TasksEffect.ShowFailedSnackBar -> onShowSnackBar(
-                    unKnownErrorMessage,
+                    context.getString(R.string.error_unknown),
                     CustomSnackBarStatus.Failure
                 )
 
                 is TasksEffect.ShowSuccessAddTaskSnackBar -> onShowSnackBar(
-                    successAddTask,
+                    context.getString(R.string.add_task_success),
                     CustomSnackBarStatus.Success
                 )
 
                 is TasksEffect.ShowSuccessEditTaskSnackBar -> onShowSnackBar(
-                    successEditTask,
+                    context.getString(R.string.edit_task_success),
                     CustomSnackBarStatus.Success
                 )
 
                 is TasksEffect.ShowFailedAddTaskSnackBar -> onShowSnackBar(
-                    failAddTask,
+                    context.getString(R.string.add_task_fail),
                     CustomSnackBarStatus.Failure
                 )
 
                 is TasksEffect.ShowFailedEditTaskSnackBar -> onShowSnackBar(
-                    failEditTask,
+                    context.getString(R.string.edit_task_fail),
+                    CustomSnackBarStatus.Failure
+                )
+
+                TasksEffect.ShowFailedWrongDateTaskSnackBar -> onShowSnackBar(
+                    context.getString(R.string.wrong_selected_date_error),
                     CustomSnackBarStatus.Failure
                 )
             }
@@ -310,7 +303,6 @@ private fun DateContainer(
     val dateOfDay: Int = currentSelectedDate.dayOfMonth
     val daysOfMonth: List<Int> = currentSelectedDate.monthDays()
     val lazyListState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
     val layoutDirection = LocalLayoutDirection.current
 
 
@@ -411,10 +403,16 @@ private fun DayContainer(
         verticalArrangement = Arrangement.Center,
     ) {
 
-        val dateOfDayColor = animateColor(condition = isClicked, trueColor = AppTheme.color.onPrimary, falseColor = AppTheme.color.body)
+        val dateOfDayColor = animateColor(
+            condition = isClicked,
+            trueColor = AppTheme.color.onPrimary,
+            falseColor = AppTheme.color.body
+        )
 
         val dayColor = animateColor(
-            condition = isClicked, trueColor = AppTheme.color.onPrimaryCaption,falseColor = AppTheme.color.hint
+            condition = isClicked,
+            trueColor = AppTheme.color.onPrimaryCaption,
+            falseColor = AppTheme.color.hint
         )
 
         Text(

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksUiState.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksUiState.kt
@@ -17,8 +17,10 @@ data class TasksUiState @OptIn(ExperimentalUuidApi::class) constructor(
             .toLocalDateTime(TimeZone.currentSystemDefault())
             .date,
     val tasks: List<TaskUi> = emptyList(),
-    val selectedDeleteTaskId : Uuid? = null,
+    val selectedDeleteTaskId: Uuid? = null,
     val selectedTask: TaskUi? = null,
+    val selectedDate: LocalDate = currentDate,
+    val isSelectedDateBeforeCurrentDate: Int = 0,
     val isDateDialogVisible: Boolean = false,
     val currentSelectedTaskStatusUi: TaskStatusUi = TaskStatusUi.TODO,
     val isAddTaskBottomSheetVisible: Boolean = false,

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/tasks/TasksViewModel.kt
@@ -68,6 +68,12 @@ class TasksViewModel(
     }
 
     override fun onFabButtonClicked() {
+        if (_taskUiState.value.isSelectedDateBeforeCurrentDate < 0) {
+            tryToExecute {
+                _effect.emit(TasksEffect.ShowFailedWrongDateTaskSnackBar)
+            }
+            return
+        }
         if (_taskUiState.value.addEditTaskUiState.categories.isEmpty()) {
             loadCategories()
         }
@@ -162,6 +168,12 @@ class TasksViewModel(
                 month = currentDate.month,
                 dayOfMonth = dayNumber,
             )
+        _taskUiState.update {
+            it.copy(
+                selectedDate = updatedDate,
+                isSelectedDateBeforeCurrentDate = updatedDate.compareTo(currentDate)
+            )
+        }
         loadTasksForDate(updatedDate)
     }
 
@@ -399,7 +411,7 @@ class TasksViewModel(
                             AddEditTaskUiState.TaskAction.ADD
                         )
                     }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
 
             }
         }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -130,6 +130,7 @@
     <string name="close">اغلاق</string>
     <string name="delete_category_success">تم حذف الفئة بنجاح</string>
     <string name="today">اليوم, %1$s</string>
+    <string name="wrong_selected_date_error">لا يمكن تعيين مهمة في تاريخ سابق</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,5 +127,6 @@
     <string name="close">Close</string>
     <string name="delete_category_success">Category Deleted successfully</string>
     <string name="today">today, %1$s</string>
+    <string name="wrong_selected_date_error">Cannot assign a task to a past date</string>
 
 </resources>


### PR DESCRIPTION
## Description
This PR introduces a check to prevent users from creating  tasks with a selected date in the past.

---

## Changes Made
List the changes introduced in this pull request:

- Added a new `TasksEffect.ShowFailedWrongDateTaskSnackBar` to signal this error.
- Updated `TasksViewModel` to verify the selected date before clicking the ADD FAB button.
- Included corresponding string resources for the error message in both English and Arabic.
- Modified `TasksScreen` to display the "wrong date" snackbar when the respective effect is received.
- Updated `TasksUiState` to include `selectedDate` and `isSelectedDateBeforeCurrentDate` to track the selected date and its relation to the current date.

---

## Screenshots (if applicable)
<img src="https://github.com/user-attachments/assets/7f1d738a-5536-4a47-9914-970db03489ae" width="300"/>

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.
