### PR TITLE
Rotterdam- Fix home screen last dance

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/bottomSheets/taskDetails/TaskDetailsBottomSheet.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/bottomSheets/taskDetails/TaskDetailsBottomSheet.kt
@@ -74,6 +74,8 @@ fun TaskDetailsBottomSheet(
     modifier: Modifier = Modifier,
     onDismissRequest: () -> Unit = {},
 ) {
+    if (taskDetailsState.selectedTask == null) return
+
     CustomBottomSheet(
         modifier = modifier,
         onDismissRequest = onDismissRequest,
@@ -131,8 +133,8 @@ private fun TaskDetailsSection(
                 painter = rememberAsyncImagePainter(
                     model = imageModel(
                         context,
-                        taskDetailsState.task.categoryUi.image
-                    )
+                        taskDetailsState.selectedTask?.categoryUi?.image!!,
+                    ),
                 ),
                 contentDescription = stringResource(id = R.string.category_image),
                 modifier = Modifier
@@ -142,14 +144,14 @@ private fun TaskDetailsSection(
 
         with(taskDetailsState) {
             Text(
-                text = task.title,
+                text = selectedTask?.title!!,
                 color = AppTheme.color.title,
                 style = AppTheme.textStyle.title.medium,
                 modifier = Modifier.padding(top = 8.dp),
             )
 
             Text(
-                text = task.description,
+                text = selectedTask.description,
                 color = AppTheme.color.body,
                 style = AppTheme.textStyle.body.medium,
                 modifier = Modifier.padding(top = 8.dp),
@@ -164,30 +166,31 @@ private fun TaskDetailsSection(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 TaskStatusChip(
-                    taskStatusUi = task.status,
+                    taskStatusUi = selectedTask.status,
                     modifier = Modifier.animateContentSize(),
                 )
                 PriorityChip(
-                    priorityUi = task.priority,
+                    priorityUi = selectedTask.priority,
                     isSelected = true,
                 )
             }
 
-            AnimatedVisibility(visible = task.status != TaskStatusUi.DONE) {
+            AnimatedVisibility(visible = selectedTask.status != TaskStatusUi.DONE) {
                 TaskActionsSection(
                     isLoading = isLoading,
                     onMoveToNextStatus = onMoveToNextStatus,
                     onEditClick = {
                         onEditClick(
-                            taskDetailsState.task.id.toString(),
-                            taskDetailsState.task.title,
-                            taskDetailsState.task.description,
-                            taskDetailsState.task.date.getStringDateFromLocalDate(),
-                            taskDetailsState.task.priority,
-                            taskDetailsState.task.categoryUi.id.toString(),
+                            taskDetailsState.selectedTask?.id.toString(),
+                            taskDetailsState.selectedTask?.title!!,
+                            taskDetailsState.selectedTask.description,
+                            taskDetailsState.selectedTask.date.getStringDateFromLocalDate(),
+                            taskDetailsState.selectedTask.priority,
+                            taskDetailsState.selectedTask.categoryUi.id
+                                .toString(),
                         )
                     },
-                    currentStatus = task.status
+                    currentStatus = selectedTask.status
                 )
             }
         }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/bottomSheets/taskDetails/TaskDetailsUiState.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/bottomSheets/taskDetails/TaskDetailsUiState.kt
@@ -3,6 +3,6 @@ package com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails
 import com.amsterdam.cutetudee.presentation.model.TaskUi
 
 data class TaskDetailsUiState(
-    val task: TaskUi,
+    val selectedTask: TaskUi? = null,
     val isLoading: Boolean = false,
 )

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeMapper.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeMapper.kt
@@ -14,8 +14,7 @@ import kotlin.uuid.ExperimentalUuidApi
 
 
 @OptIn(ExperimentalUuidApi::class)
-fun Pair<List<Task>, List<Category>>.toHomeUiState(): HomeUiState {
-
+fun Pair<List<Task>, List<Category>>.toHomeUiState(homeUiState: HomeUiState): HomeUiState {
     val (tasks, categories) = this
 
     fun Task.toTaskDetails(): HomeUiState.TaskDetails {
@@ -39,7 +38,7 @@ fun Pair<List<Task>, List<Category>>.toHomeUiState(): HomeUiState {
             .now()
             .toLocalDateTime(TimeZone.currentSystemDefault())
             .date
-    return HomeUiState(
+    return homeUiState.copy(
         currentDate = date,
         todoTasks = toDoTasks,
         inProgressTasks = inProgressTasks,

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeScreen.kt
@@ -25,7 +25,7 @@ import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.domain.entity.Task
 import com.amsterdam.cutetudee.presentation.LocalNavController
 import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsBottomSheet
-import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsUiState
+import com.amsterdam.cutetudee.presentation.component.AddOrEditTaskBottomSheet
 import com.amsterdam.cutetudee.presentation.component.CustomFloatingActionButton
 import com.amsterdam.cutetudee.presentation.component.LoadingIndicator
 import com.amsterdam.cutetudee.presentation.component.NoTasksContainer
@@ -34,12 +34,11 @@ import com.amsterdam.cutetudee.presentation.component.chip.tast_status.TaskStatu
 import com.amsterdam.cutetudee.presentation.component.custom_padding.bottomNavigationBarPadding
 import com.amsterdam.cutetudee.presentation.component.custom_snack_bar.CustomSnackBarStatus
 import com.amsterdam.cutetudee.presentation.navigation.Screen
+import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractionListener
+import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import com.amsterdam.cutetudee.presentation.screens.home.component.OverlayBoxContent
 import com.amsterdam.cutetudee.presentation.screens.home.component.TaskSection
 import com.amsterdam.cutetudee.presentation.screens.home.component.TopCuteTudeeAppBar
-import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskInteractionListener
-import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
-import com.amsterdam.cutetudee.presentation.component.AddOrEditTaskBottomSheet
 import com.amsterdam.cutetudee.presentation.theme.AppTheme
 import com.amsterdam.cutetudee.presentation.utils.toStringFormatedDate
 import kotlinx.coroutines.flow.collectLatest
@@ -149,10 +148,9 @@ private fun HomeScreenContent(
             )
         }
         if (homeUiState.showTaskDetailsBottomSheet) {
-            if (homeUiState.selectedTask == null) return
-            val state = TaskDetailsUiState(homeUiState.selectedTask, false)
+            if (homeUiState.taskDetailsUiState.selectedTask == null) return
             TaskDetailsBottomSheet(
-                taskDetailsState = state,
+                taskDetailsState = homeUiState.taskDetailsUiState,
                 onMoveToNextStatus = homeInteraction::onMoveToNextStatus,
                 onEditClick = homeInteraction::onEditTaskClicked,
                 onDismissRequest = homeInteraction::onDismissTaskDetailsBottomSheet

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeUiState.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeUiState.kt
@@ -5,8 +5,8 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.domain.entity.Task
+import com.amsterdam.cutetudee.presentation.bottomSheets.taskDetails.TaskDetailsUiState
 import com.amsterdam.cutetudee.presentation.component.chip.priority.PriorityUi
-import com.amsterdam.cutetudee.presentation.model.TaskUi
 import com.amsterdam.cutetudee.presentation.screens.common.AddEditTaskUiState
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
@@ -32,7 +32,7 @@ data class HomeUiState(
     val showAddTaskBottomSheet: Boolean = false,
     val showTaskDetailsBottomSheet: Boolean = false,
     val showEditTaskBottomSheet: Boolean = false,
-    val selectedTask: TaskUi? = null,
+    val taskDetailsUiState: TaskDetailsUiState = TaskDetailsUiState(),
     @StringRes val errorMessageId: Int? = null,
     val addEditTaskUiState: AddEditTaskUiState = AddEditTaskUiState()
 ) {

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.cutetudee.presentation.screens.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.cutetudee.R
@@ -31,6 +32,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -92,7 +94,7 @@ class HomeViewModel(
     private fun createHomeUiState(
         tasks: List<Task>,
         categories: List<Category>,
-    ): HomeUiState = (tasks to categories).toHomeUiState()
+    ): HomeUiState = (tasks to categories).toHomeUiState(_homeState.value)
 
     private fun determineMoodState(state: HomeUiState): MoodState =
         when {
@@ -130,7 +132,7 @@ class HomeViewModel(
                 _homeState.update {
                     it.copy(
                         showTaskDetailsBottomSheet = true,
-                        selectedTask = taskUi
+                        taskDetailsUiState = it.taskDetailsUiState.copy(selectedTask = taskUi),
                     )
                 }
             } catch (e: Exception) {
@@ -140,7 +142,12 @@ class HomeViewModel(
     }
 
     override fun onDismissTaskDetailsBottomSheet() {
-        _homeState.update { it.copy(showTaskDetailsBottomSheet = false, selectedTask = null) }
+        _homeState.update {
+            it.copy(
+                showTaskDetailsBottomSheet = false,
+                taskDetailsUiState = it.taskDetailsUiState.copy(selectedTask = null),
+            )
+        }
     }
 
     override fun onEditTaskClicked(
@@ -167,7 +174,9 @@ class HomeViewModel(
                     selectedCategoryId = selectedCategoryId,
                     categories = _homeState.value.addEditTaskUiState.categories,
                     taskAction = AddEditTaskUiState.TaskAction.EDIT,
-                    status = homeState.value.selectedTask?.status?.toTaskStatus()
+                    status =
+                        homeState.value.taskDetailsUiState.selectedTask
+                            ?.status?.toTaskStatus()
                         ?: Task.Status.TODO
                 )
             )
@@ -176,21 +185,40 @@ class HomeViewModel(
 
     override fun onDismissEditBottomSheet() {
         _homeState.update {
-            it.copy(showEditTaskBottomSheet = false, selectedTask = null)
+            it.copy(
+                showEditTaskBottomSheet = false,
+                taskDetailsUiState = it.taskDetailsUiState.copy(selectedTask = null)
+            )
         }
     }
 
     @OptIn(ExperimentalUuidApi::class)
     override fun onMoveToNextStatus(taskStatusUi: TaskStatusUi) {
-        if (_homeState.value.selectedTask == null) return
-        val updatedSelectedTask = _homeState.value.selectedTask!!.copy(status = taskStatusUi)
-        val taskToUpdate: Task = _homeState.value.selectedTask!!.toTask()
-            .copy(status = taskStatusUi.toTaskStatus())
+        _homeState.update {
+            it.copy(
+                taskDetailsUiState = it.taskDetailsUiState.copy(isLoading = true),
+            )
+        }
 
         viewModelScope.launch(dispatcherProvider.IO) {
             try {
-                taskService.editTask(taskToUpdate)
-                _homeState.update { it.copy(selectedTask = updatedSelectedTask) }
+                checkNotNull(_homeState.value.taskDetailsUiState.selectedTask)
+                val updatedSelectedTask =
+                    _homeState.value.taskDetailsUiState.selectedTask!!
+                        .copy(status = taskStatusUi)
+
+                taskService.editTask(updatedSelectedTask.toTask())
+                withContext(dispatcherProvider.Main) {
+                    _homeState.update {
+                        it.copy(
+                            taskDetailsUiState =
+                                it.taskDetailsUiState.copy(
+                                    selectedTask = updatedSelectedTask,
+                                    isLoading = false,
+                                ),
+                        )
+                    }
+                }
                 _homeEffect.emit(HomeEffect.ShowTaskStatusEditedSuccessfullySnackBar)
             } catch (e: Exception) {
                 _homeEffect.emit(HomeEffect.ShowTaskStatusFailedToEditSnackBar)
@@ -352,7 +380,8 @@ class HomeViewModel(
                 updateIsLoading(false)
                 onDismiss()
                 _homeEffect.emit(HomeEffect.ShowTaskAddedSuccessfullySnackBar)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.d("TAG", "addTask: ${e.printStackTrace()}")
                 updateIsLoading(false)
                 _homeEffect.emit(HomeEffect.ShowTaskAddedFailedSnackBar)
             }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/HomeViewModel.kt
@@ -55,9 +55,9 @@ class HomeViewModel(
     }
 
     private fun loadHomeScreenStates() {
+        _homeState.update { it.copy(isLoading = true) }
         viewModelScope.launch(dispatcherProvider.IO) {
             try {
-                _homeState.update { it.copy(isLoading = true) }
                 appSettingsService.getThemeMode().collectLatest { mode ->
                     val isDarkMode = mode == ThemeMode.DARK
                     observeHomeStateChanges(isDarkMode)

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/ImageMood.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/ImageMood.kt
@@ -5,14 +5,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.presentation.theme.AppTheme
+import com.amsterdam.cutetudee.presentation.theme.CuteTudeeTheme
 import com.amsterdam.cutetudee.presentation.utils.ThemeAndLocalePreviews
 
 @Composable
@@ -23,9 +26,9 @@ fun ImageMood(
         modifier = Modifier
             .offset(y = 8.dp, x = 2.dp)
             .size(65.dp)
-            .background(
-                color = AppTheme.color.overlay, shape = RoundedCornerShape(100)
-            )
+            .clip(CircleShape)
+            .alpha(0.16f)
+            .background(AppTheme.color.primary),
     )
     Image(
         painter = image,
@@ -36,7 +39,9 @@ fun ImageMood(
 @Composable
 @ThemeAndLocalePreviews
 private fun ImageMoodPreview() {
-    ImageMood(
-        image = painterResource(id = R.drawable.tudee_image_neutral),
-    )
+    CuteTudeeTheme {
+        ImageMood(
+            image = painterResource(id = R.drawable.tudee_image_neutral),
+        )
+    }
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/OverlayBoxContent.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/home/component/OverlayBoxContent.kt
@@ -22,6 +22,7 @@ import com.amsterdam.cutetudee.R
 import com.amsterdam.cutetudee.domain.entity.Task
 import com.amsterdam.cutetudee.presentation.screens.home.MoodState
 import com.amsterdam.cutetudee.presentation.theme.AppTheme
+import com.amsterdam.cutetudee.presentation.theme.CuteTudeeTheme
 import com.amsterdam.cutetudee.presentation.utils.ThemeAndLocalePreviews
 import com.amsterdam.cutetudee.presentation.utils.animation.SlideDirection
 import com.amsterdam.cutetudee.presentation.utils.animation.fadeAnimation
@@ -102,9 +103,7 @@ fun OverlayBoxContent(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 12.dp, end = 12.dp
-//                        , bottom = 12.dp
-                    ),
+                    .padding(start = 12.dp, end = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
@@ -112,7 +111,8 @@ fun OverlayBoxContent(
                     countOfTasks = numberOfCompletedTask,
                     tasksState = Task.Status.DONE,
                     backgroundColor = AppTheme.color.greenAccent,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
                         .fadeAnimation(durationMillis = 400)
                         .slide(direction = SlideDirection.Up, durationMillis = 600, distance = 20.dp)
                         .padding(bottom = 12.dp)
@@ -121,18 +121,20 @@ fun OverlayBoxContent(
                     countOfTasks = numberOfInProgressTask,
                     tasksState = Task.Status.IN_PROGRESS,
                     backgroundColor = AppTheme.color.yellowAccent,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
                         .fadeAnimation(durationMillis = 400)
-                        .slide(direction = SlideDirection.Up , delayMillis = 100 , durationMillis = 600, distance = 20.dp)
+                        .slide(direction = SlideDirection.Up, delayMillis = 100, durationMillis = 600, distance = 20.dp)
                         .padding(bottom = 12.dp)
                 )
                 OverviewCard(
                     countOfTasks = numberOfToDoTask,
                     tasksState = Task.Status.TODO,
                     backgroundColor = AppTheme.color.purpleAccent,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
                         .fadeAnimation(durationMillis = 400)
-                        .slide(direction = SlideDirection.Up , delayMillis = 200 , durationMillis = 600, distance = 20.dp)
+                        .slide(direction = SlideDirection.Up, delayMillis = 200, durationMillis = 600, distance = 20.dp)
                         .padding(bottom = 12.dp)
                 )
             }
@@ -143,12 +145,14 @@ fun OverlayBoxContent(
 @Composable
 @ThemeAndLocalePreviews
 private fun OverlayBoxContentPreview() {
-    OverlayBoxContent(
-        currentDate = "22 Jun 2025",
-        numberOfCompletedTask = 3,
-        totalNumberOfTasks = 10,
-        numberOfToDoTask = 8,
-        numberOfInProgressTask = 1,
-        moodState = MoodState.NOTHING_IN_YOUR_LIST
-    )
+    CuteTudeeTheme {
+        OverlayBoxContent(
+            currentDate = "22 Jun 2025",
+            numberOfCompletedTask = 3,
+            totalNumberOfTasks = 10,
+            numberOfToDoTask = 8,
+            numberOfInProgressTask = 1,
+            moodState = MoodState.NOTHING_IN_YOUR_LIST,
+        )
+    }
 }


### PR DESCRIPTION
## Description
This PR refactors the `HomeUiState` to encapsulate the state related to the Task Details Bottom Sheet within a new `TaskDetailsUiState` data class.

Specifically, the `selectedTask` property is moved from `HomeUiState` to `TaskDetailsUiState`, and `TaskDetailsUiState` is added as a property to `HomeUiState`.

This change improves the organization of the UI state and makes it easier to manage the state of the Task Details Bottom Sheet.

---

## Changes Made
List the changes introduced in this pull request:

The following files were modified:
- `TaskDetailsUiState.kt`: Renamed `task` to `selectedTask` and made it nullable.
- `TaskDetailsBottomSheet.kt`: Updated to use `selectedTask` from `TaskDetailsUiState` and added a null check for `selectedTask`.
- `HomeViewModel.kt`:
    - Updated logic for showing and dismissing the Task Details Bottom Sheet to use `taskDetailsUiState`.
    - Updated `onMoveToNextStatus` to manage loading state within `taskDetailsUiState`.
    - Modified `createHomeUiState` to accept the current `HomeUiState` for copying.
- `HomeScreen.kt`: Updated to use `taskDetailsUiState` when showing the Task Details Bottom Sheet.
- `HomeMapper.kt`: Modified `toHomeUiState` to copy existing `HomeUiState` values.
- `HomeUiState.kt`: Replaced `selectedTask` with `taskDetailsUiState`.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---