### PR TITLE
Utrecht update/prevent duplicate category names

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/data/service/CategoryServiceImpl.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/data/service/CategoryServiceImpl.kt
@@ -7,6 +7,7 @@ import com.amsterdam.cutetudee.data.mapper.toCategoryListFlow
 import com.amsterdam.cutetudee.domain.entity.Category
 import com.amsterdam.cutetudee.domain.service.CategoryService
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -30,6 +31,13 @@ class CategoryServiceImpl(
 
     override suspend fun getCategoryById(categoryId: Uuid): Category {
         return categoryDao.getCategoryById(categoryId.toString()).toCategory()
+    }
+
+    override suspend fun isCategoryNameExists(name: String): Boolean {
+        val existedCategories = getAllCategories().first()
+        return existedCategories.any {
+            it.name.trim().equals(name.trim(), ignoreCase = true)
+        }
     }
 
     override fun getAllCategories(): Flow<List<Category>> {

--- a/app/src/main/java/com/amsterdam/cutetudee/domain/service/CategoryService.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/domain/service/CategoryService.kt
@@ -11,5 +11,6 @@ interface CategoryService {
     suspend fun editCategory(category: Category)
     suspend fun deleteCategory(categoryId: Uuid)
     suspend fun getCategoryById(categoryId: Uuid): Category
+    suspend fun isCategoryNameExists(name: String): Boolean
     fun getAllCategories(): Flow<List<Category>>
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryEffect.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryEffect.kt
@@ -3,5 +3,6 @@ package com.amsterdam.cutetudee.presentation.screens.category
 sealed class CategoryEffect {
     data object ShowEditSnackBar : CategoryEffect()
     data object ShowAddSnackBar : CategoryEffect()
+    data object ShowDuplicateNameSnackBar : CategoryEffect()
     data object ShowError : CategoryEffect()
 }

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryScreen.kt
@@ -50,6 +50,7 @@ fun CategoryScreen(
     val state by viewModel.state.collectAsState()
     val addSuccessMessage = stringResource(R.string.add_category_success)
     val editSuccessMessage = stringResource(R.string.edit_category_success)
+    val duplicateCategoryNameMessage = stringResource(R.string.category_already_exist)
     val failMessage = stringResource(R.string.error_unknown)
     LaunchedEffect(Unit) {
         viewModel.effect.collectLatest { effect ->
@@ -68,6 +69,11 @@ fun CategoryScreen(
                     )
                 }
 
+                CategoryEffect.ShowDuplicateNameSnackBar ->
+                    onShowSnackBar(
+                        duplicateCategoryNameMessage,
+                        CustomSnackBarStatus.Failure
+                    )
                 CategoryEffect.ShowError -> {
                     onShowSnackBar(
                         failMessage,
@@ -129,6 +135,7 @@ private fun CategoryScreenContent(
                 modifier = Modifier
                     .background(AppTheme.color.surface)
                     .padding(horizontal = 16.dp)
+                    .fillMaxSize()
             ) {
                 itemsIndexed(state.categories) {index, categoryUiState ->
                     BadgedCategoryItem(

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/category/CategoryViewModel.kt
@@ -98,6 +98,19 @@ class CategoryViewModel(
         }
         viewModelScope.launch(dispatcherProvider.IO) {
             try {
+                val isCategoryDuplicated =
+                    categoryService.isCategoryNameExists(state.value.addBottomSheet.name)
+                if (isCategoryDuplicated) {
+                    updateState {
+                        it.copy(
+                            addBottomSheet = it.addBottomSheet.copy(
+                                isLoading = false,
+                            )
+                        )
+                    }
+                    sendNewEffect(CategoryEffect.ShowDuplicateNameSnackBar)
+                    return@launch
+                }
                 categoryService.addCategory(
                     Category(
                         image = state.value.addBottomSheet.image.toString(),

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -116,6 +116,7 @@
 
     <string name="load_task_fail">لم يتم العثور على المهمة</string>
     <string name="load_category_fail">لم يتم العثور على الفئة</string>
+    <string name="category_already_exist">هذه الفئة موجودة بالفعل.</string>
 
     <string name="load_data_fail">لم يتم العثور على البيانات</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="error_invalid_category_input">Invalid category input</string>
     <string name="error_no_categories_found">No categories found</string>
     <string name="error_category_not_found">Category not found</string>
+    <string name="category_already_exist">This Category Already Exists.</string>
 
     <string name="error_unknown">Something went wrong</string>
 


### PR DESCRIPTION
## Description

This PR adds validation for the 'Add Category' action to check if the Category name already exists.

---

## Changes Made

- Added `isCategoryNameExists` method in `CategoryService` and implemented it.
- Added `ShowDuplicateNameSnackBar` in `CategoryEffect`
- Added new string resources for `category_already_exist`

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.

---