### PR TITLE
fix onBoardingBackground image position

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/onBoarding/OnBoardingScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/onBoarding/OnBoardingScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -26,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -82,9 +82,7 @@ fun OnboardingContent(
             .navigationBarsPadding()
     ) {
         Image(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(.7f),
+            modifier = Modifier.align(AbsoluteAlignment.TopRight),
             painter = painterResource(AppTheme.images.onBoardingBackground),
             contentDescription = null,
             contentScale = ContentScale.FillBounds

--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/splash/SplashScreen.kt
@@ -3,13 +3,12 @@ package com.amsterdam.cutetudee.presentation.screens.splash
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -55,9 +54,7 @@ private fun SplashContent() {
             painter = painterResource(AppTheme.images.onBoardingBackground),
             contentDescription = null,
             contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(0.7f)
+            modifier = Modifier.align(AbsoluteAlignment.TopRight)
         )
         Box(
             modifier = Modifier.align(Alignment.Center)


### PR DESCRIPTION
# Pull Request Template

## Description
refactor the stretch of the background image in on boarding and in splach screen
---

## Changes Made
List the changes introduced in this pull request:

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.

![Screenshot_20250627_042420](https://github.com/user-attachments/assets/ec80da32-62c1-415f-99ba-88b411254ef6)
![Screenshot_20250627_042453](https://github.com/user-attachments/assets/d35a3bd3-62d1-4da1-b8f8-dc0b4b5428d9)

---

## Checklist
Please ensure the following tasks are completed:

- [👍 ] My code follows the code style of this project
- [ 👍] Changes have been tested manually and verified.
- [ 👍] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [👍 ] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [ 👍] Commit messages should follow the atomic commits convention.

---

## Additional Comments
Add any additional information or context about the pull request here.