### PR TITLE
Rotterdam bugfix/fix enable button

### DIFF
--- a/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/categoryDetails/CategoryDetailsViewModel.kt
+++ b/app/src/main/java/com/amsterdam/cutetudee/presentation/screens/categoryDetails/CategoryDetailsViewModel.kt
@@ -103,7 +103,7 @@ class CategoryDetailsViewModel(
                         hideEditBottomSheet = false,
                         categoryBottomSheetState = it.categoryBottomSheetState.copy(
                             image = selectedUriImage,
-                            name = state.value.categoryBottomSheetState.name.ifEmpty { name }
+                            name = state.value.categoryBottomSheetState.name.ifBlank { name },
                         )
                     )
                 }
@@ -137,8 +137,8 @@ class CategoryDetailsViewModel(
             it.copy(
                 categoryBottomSheetState = it.categoryBottomSheetState.copy(
                     name = text,
-                    isEnabled = text.isNotBlank()
-                )
+                    isEnabled = text.isNotBlank() && text != it.categoryItemUiState.title
+                ),
             )
         }
     }


### PR DESCRIPTION
## Description
This PR fixes an issue where the edit bottom sheet would not allow an empty category name. The `isEnabled` property of the `categoryBottomSheetState` is now updated to prevent an empty category name or same name

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

Please ensure the following Git conventions are completed:

- [x] Branch name follow this pattern: Subteam-category/task (f.e: Rotterdam-feature/login).
- [x] Commit messages should follow the atomic commits convention.